### PR TITLE
Fixed typo in predict() returns comments

### DIFF
--- a/surprise/prediction_algorithms/algo_base.py
+++ b/surprise/prediction_algorithms/algo_base.py
@@ -85,7 +85,7 @@ class AlgoBase(object):
 
             - The (raw) user id ``uid``.
             - The (raw) item id ``iid``.
-            - The true rating ``r_ui`` (:math:`\\hat{r}_{ui}`).
+            - The true rating ``r_ui`` (:math:`r_{ui}`).
             - The estimated rating (:math:`\\hat{r}_{ui}`).
             - Some additional details about the prediction that might be useful
               for later analysis.


### PR DESCRIPTION
Removed the hat on the true rating (:math:`r_u{ui}`) in the comments of the predict function's returns section.